### PR TITLE
fix: 注文確定画面で「戻る」ボタンを押した場合、リダイレクト先のお届け先情報入力ページが正常に表示されない問題を修正

### DIFF
--- a/delivery_form.php
+++ b/delivery_form.php
@@ -18,6 +18,15 @@ $order_datas = [
     'payment_method'  => ''
 ];
 
+// 合計金額をセッションから取得
+$total_amount=isset($_SESSION["total_amount"]) ? $_SESSION["total_amount"] : 0;
+
+// $_POST["total_amount"]があれば上書き
+if(isset($_POST["total_amount"])){
+    $total_amount=$_POST["total_amount"];
+    $_SESSION["total_amount"]=$total_amount;// セッションをPOSTの値で上書き
+}
+
 
 $errors=[];
 
@@ -133,7 +142,7 @@ if($_SERVER["REQUEST_METHOD"] == "POST"){
         <div style="text-align:end">
             <button type="button" onclick="location.href='view_cart.php'">戻る</button>
             <input type="hidden" name="token" value="<?php echo h($_SESSION['token']); ?>">
-            <input type="hidden" name="total_amount" value="<?php echo $_POST["total_amount"];?>">
+            <input type="hidden" name="total_amount" value="<?php echo h($total_amount); ?>">
             <input type="hidden" name="submit" value="1">
             <button type="submit">次へ進む</button>
         </div>

--- a/order_confirm.php
+++ b/order_confirm.php
@@ -28,6 +28,9 @@ $order_datas = [
     'payment_method'  => ''
 ];
 
+// total_amountをセッションから取得
+$sum = isset($_SESSION["total_amount"]) ? $_SESSION["total_amount"] : 0;
+
 //注文商品情報の中身を格納する変数の定義と初期化
 $item_datas=[];
 
@@ -211,6 +214,7 @@ if($_SERVER["REQUEST_METHOD"] == "POST"){
             unset($_SESSION["cart_items"]);
             unset($_SESSION["order_datas"]);
             unset($_SESSION["token"]);
+            unset($_SESSION["total_amount"]);
             header("location: order_complete.php?order_id=".$order_id);
             exit;
         } catch (PDOException $e) {
@@ -315,7 +319,7 @@ if($_SERVER["REQUEST_METHOD"] == "POST"){
         <div class="confirm_btn_container">
             <button onclick="location.href='delivery_form.php'">戻る</button>
             <form action="order_confirm.php" method="post">
-                <input type="hidden" name="total_amount" value="<?php echo $sum;?>">
+                <input type="hidden" name="total_amount" value="<?php echo h($sum);?>">
                 <input type="hidden" name="token" value="<?php echo h($_SESSION['token']); ?>">
                 <input type="hidden" name="confirm" value="1">
                 <button type="submit">注文確定</button>

--- a/view_cart.php
+++ b/view_cart.php
@@ -170,6 +170,8 @@ if($_SERVER["REQUEST_METHOD"]=="GET"){
 
             <?php endforeach;?>
 
+            <?php $_SESSION["total_amount"]=$sum;?>
+
 
         </div>
 


### PR DESCRIPTION
合計金額をPOSTで送信していたことが原因だったので、セッションで扱うことにした。
view_cart.phpで$_SESSION["total_amount"]に値を格納し、以降のページではセッション変数から値を取ってくるようにする。